### PR TITLE
Expose object tracker for fake clientsets

### DIFF
--- a/cmd/client-gen/generators/fake/generator_fake_for_clientset.go
+++ b/cmd/client-gen/generators/fake/generator_fake_for_clientset.go
@@ -125,7 +125,7 @@ func NewSimpleClientset(objects ...runtime.Object) *Clientset {
 		}
 	}
 
-	cs := &Clientset{}
+	cs := &Clientset{tracker: o}
 	cs.discovery = &fakediscovery.FakeDiscovery{Fake: &cs.Fake}
 	cs.AddReactor("*", "*", testing.ObjectReaction(o))
 	cs.AddWatchReactor("*", func(action testing.Action) (handled bool, ret watch.Interface, err error) {
@@ -147,10 +147,15 @@ func NewSimpleClientset(objects ...runtime.Object) *Clientset {
 type Clientset struct {
 	testing.Fake
 	discovery *fakediscovery.FakeDiscovery
+	tracker testing.ObjectTracker
 }
 
 func (c *Clientset) Discovery() discovery.DiscoveryInterface {
 	return c.discovery
+}
+
+func (c *Clientset) Tracker() testing.ObjectTracker {
+	return c.tracker
 }
 `
 


### PR DESCRIPTION
Not every object kind can be registered via tracker .Add() called as part of
SimpleClientset initialization. This is because .Add() relies on
UnsafeGuessKindToResource to convert object kinds into resource type names,
which is broken for some resources. An example of an affected kind is
NetworkAttachmentDefinitions CRD that uses network-attachment-definitions as
its resource type name. When UnsafeGuessKindToResource is called for this kind,
it returns networkattachmentdefinitions (without dashes).

As per the comment inside .Add, kinds affected by UnsafeGuessKindToResource
deficiencies should instead register objects using tracker .Create() method.
Problem is, current SimpleClientset struct definition doesn't expose the object
tracker in any way, which makes it impossible to properly register these kinds
at all.

To address the issue, this change modifies the definition of SimpleClientset
struct to expose the object tracker used via Tracker() method.

Sorry, we do not accept changes directly against this repository. Please see 
CONTRIBUTING.md for information on where and how to contribute instead.
