### PR TITLE
Use shell internal functionality instead of basename/dirname

### DIFF
--- a/generate-groups.sh
+++ b/generate-groups.sh
@@ -21,9 +21,9 @@ set -o pipefail
 # generate-groups generates everything for a project with external types only, e.g. a project based
 # on CustomResourceDefinitions.
 
-if [ "$#" -lt 4 ] || [ "${1}" == "--help" ]; then
+if [ $# -lt 4 ] || [ "${1}" = '--help' ]; then
   cat <<EOF
-Usage: $(basename "$0") <generators> <output-package> <apis-package> <groups-versions> ...
+Usage: ${0##*/} <generators> <output-package> <apis-package> <groups-versions> ...
 
   <generators>        the generators comma separated to run (deepcopy,defaulter,client,lister,informer) or "all".
   <output-package>    the output package name (e.g. github.com/example/project/pkg/generated).
@@ -34,22 +34,22 @@ Usage: $(basename "$0") <generators> <output-package> <apis-package> <groups-ver
 
 
 Examples:
-  $(basename "$0") all             github.com/example/project/pkg/client github.com/example/project/pkg/apis "foo:v1 bar:v1alpha1,v1beta1"
-  $(basename "$0") deepcopy,client github.com/example/project/pkg/client github.com/example/project/pkg/apis "foo:v1 bar:v1alpha1,v1beta1"
+  ${0##*/} all             github.com/example/project/pkg/client github.com/example/project/pkg/apis "foo:v1 bar:v1alpha1,v1beta1"
+  ${0##*/} deepcopy,client github.com/example/project/pkg/client github.com/example/project/pkg/apis "foo:v1 bar:v1alpha1,v1beta1"
 EOF
   exit 0
 fi
 
-GENS="$1"
-OUTPUT_PKG="$2"
-APIS_PKG="$3"
-GROUPS_WITH_VERSIONS="$4"
+GENS=$1
+OUTPUT_PKG=$2
+APIS_PKG=$3
+GROUPS_WITH_VERSIONS=$4
 shift 4
 
 (
   # To support running this script from anywhere, we have to first cd into this directory
   # so we can install the tools.
-  cd "$(dirname "${0}")"
+  cd "${0%/*}"
   go install ./cmd/{defaulter-gen,client-gen,lister-gen,informer-gen,deepcopy-gen}
 )
 
@@ -66,22 +66,22 @@ for GVs in ${GROUPS_WITH_VERSIONS}; do
   done
 done
 
-if [ "${GENS}" = "all" ] || grep -qw "deepcopy" <<<"${GENS}"; then
-  echo "Generating deepcopy funcs"
+if [ "${GENS}" = all ] || grep -qw deepcopy <<<"${GENS}"; then
+  echo 'Generating deepcopy funcs'
   "${GOPATH}/bin/deepcopy-gen" --input-dirs "$(codegen::join , "${FQ_APIS[@]}")" -O zz_generated.deepcopy --bounding-dirs "${APIS_PKG}" "$@"
 fi
 
-if [ "${GENS}" = "all" ] || grep -qw "client" <<<"${GENS}"; then
+if [ "${GENS}" = all ] || grep -qw client <<<"${GENS}"; then
   echo "Generating clientset for ${GROUPS_WITH_VERSIONS} at ${OUTPUT_PKG}/${CLIENTSET_PKG_NAME:-clientset}"
   "${GOPATH}/bin/client-gen" --clientset-name "${CLIENTSET_NAME_VERSIONED:-versioned}" --input-base "" --input "$(codegen::join , "${FQ_APIS[@]}")" --output-package "${OUTPUT_PKG}/${CLIENTSET_PKG_NAME:-clientset}" "$@"
 fi
 
-if [ "${GENS}" = "all" ] || grep -qw "lister" <<<"${GENS}"; then
+if [ "${GENS}" = all ] || grep -qw lister <<<"${GENS}"; then
   echo "Generating listers for ${GROUPS_WITH_VERSIONS} at ${OUTPUT_PKG}/listers"
   "${GOPATH}/bin/lister-gen" --input-dirs "$(codegen::join , "${FQ_APIS[@]}")" --output-package "${OUTPUT_PKG}/listers" "$@"
 fi
 
-if [ "${GENS}" = "all" ] || grep -qw "informer" <<<"${GENS}"; then
+if [ "${GENS}" = all ] || grep -qw informer <<<"${GENS}"; then
   echo "Generating informers for ${GROUPS_WITH_VERSIONS} at ${OUTPUT_PKG}/informers"
   "${GOPATH}/bin/informer-gen" \
            --input-dirs "$(codegen::join , "${FQ_APIS[@]}")" \

--- a/generate-internal-groups.sh
+++ b/generate-internal-groups.sh
@@ -21,9 +21,9 @@ set -o pipefail
 # generate-internal-groups generates everything for a project with internal types, e.g. an
 # user-provided API server based on k8s.io/apiserver.
 
-if [ "$#" -lt 5 ] || [ "${1}" == "--help" ]; then
+if [ $# -lt 5 ] || [ "${1}" = '--help' ]; then
   cat <<EOF
-Usage: $(basename "$0") <generators> <output-package> <internal-apis-package> <extensiona-apis-package> <groups-versions> ...
+Usage: ${0##*/} <generators> <output-package> <internal-apis-package> <extensiona-apis-package> <groups-versions> ...
 
   <generators>        the generators comma separated to run (deepcopy,defaulter,conversion,client,lister,informer,openapi) or "all".
   <output-package>    the output package name (e.g. github.com/example/project/pkg/generated).
@@ -34,20 +34,20 @@ Usage: $(basename "$0") <generators> <output-package> <internal-apis-package> <e
   ...                 arbitrary flags passed to all generator binaries.
 
 Examples:
-  $(basename "$0") all                           github.com/example/project/pkg/client github.com/example/project/pkg/apis github.com/example/project/pkg/apis "foo:v1 bar:v1alpha1,v1beta1"
-  $(basename "$0") deepcopy,defaulter,conversion github.com/example/project/pkg/client github.com/example/project/pkg/apis github.com/example/project/apis     "foo:v1 bar:v1alpha1,v1beta1"
+  ${0##*/} all                           github.com/example/project/pkg/client github.com/example/project/pkg/apis github.com/example/project/pkg/apis "foo:v1 bar:v1alpha1,v1beta1"
+  ${0##*/} deepcopy,defaulter,conversion github.com/example/project/pkg/client github.com/example/project/pkg/apis github.com/example/project/apis     "foo:v1 bar:v1alpha1,v1beta1"
 EOF
   exit 0
 fi
 
-GENS="$1"
-OUTPUT_PKG="$2"
-INT_APIS_PKG="$3"
-EXT_APIS_PKG="$4"
-GROUPS_WITH_VERSIONS="$5"
+GENS=$1
+OUTPUT_PKG=$2
+INT_APIS_PKG=$3
+EXT_APIS_PKG=$4
+GROUPS_WITH_VERSIONS=$5
 shift 5
 
-go install ./"$(dirname "${0}")"/cmd/{defaulter-gen,conversion-gen,client-gen,lister-gen,informer-gen,deepcopy-gen,openapi-gen}
+go install ./"${0%/*}"/cmd/{defaulter-gen,conversion-gen,client-gen,lister-gen,informer-gen,deepcopy-gen,openapi-gen}
 
 function codegen::join() { local IFS="$1"; shift; echo "$*"; }
 
@@ -70,22 +70,22 @@ for GVs in ${GROUPS_WITH_VERSIONS}; do
   done
 done
 
-if [ "${GENS}" = "all" ] || grep -qw "deepcopy" <<<"${GENS}"; then
-  echo "Generating deepcopy funcs"
+if [ "${GENS}" = all ] || grep -qw deepcopy <<<"${GENS}"; then
+  echo 'Generating deepcopy funcs'
   "${GOPATH}/bin/deepcopy-gen" --input-dirs "$(codegen::join , "${ALL_FQ_APIS[@]}")" -O zz_generated.deepcopy --bounding-dirs "${INT_APIS_PKG},${EXT_APIS_PKG}" "$@"
 fi
 
-if [ "${GENS}" = "all" ] || grep -qw "defaulter" <<<"${GENS}"; then
-  echo "Generating defaulters"
+if [ "${GENS}" = all ] || grep -qw defaulter <<<"${GENS}"; then
+  echo 'Generating defaulters'
   "${GOPATH}/bin/defaulter-gen"  --input-dirs "$(codegen::join , "${EXT_FQ_APIS[@]}")" -O zz_generated.defaults "$@"
 fi
 
-if [ "${GENS}" = "all" ] || grep -qw "conversion" <<<"${GENS}"; then
-  echo "Generating conversions"
+if [ "${GENS}" = all ] || grep -qw conversion <<<"${GENS}"; then
+  echo 'Generating conversions'
   "${GOPATH}/bin/conversion-gen" --input-dirs "$(codegen::join , "${ALL_FQ_APIS[@]}")" -O zz_generated.conversion "$@"
 fi
 
-if [ "${GENS}" = "all" ] || grep -qw "client" <<<"${GENS}"; then
+if [ "${GENS}" = all ] || grep -qw client <<<"${GENS}"; then
   echo "Generating clientset for ${GROUPS_WITH_VERSIONS} at ${OUTPUT_PKG}/${CLIENTSET_PKG_NAME:-clientset}"
   if [ -n "${INT_APIS_PKG}" ]; then
     IFS=" " read -r -a APIS <<< "$(printf '%s/ ' "${INT_FQ_APIS[@]}")"
@@ -94,7 +94,7 @@ if [ "${GENS}" = "all" ] || grep -qw "client" <<<"${GENS}"; then
   "${GOPATH}/bin/client-gen" --clientset-name "${CLIENTSET_NAME_VERSIONED:-versioned}" --input-base "" --input "$(codegen::join , "${EXT_FQ_APIS[@]}")" --output-package "${OUTPUT_PKG}/${CLIENTSET_PKG_NAME:-clientset}" "$@"
 fi
 
-if [ "${GENS}" = "all" ] || grep -qw "lister" <<<"${GENS}"; then
+if [ "${GENS}" = all ] || grep -qw lister <<<"${GENS}"; then
   echo "Generating listers for ${GROUPS_WITH_VERSIONS} at ${OUTPUT_PKG}/listers"
   "${GOPATH}/bin/lister-gen" --input-dirs "$(codegen::join , "${ALL_FQ_APIS[@]}")" --output-package "${OUTPUT_PKG}/listers" "$@"
 fi


### PR DESCRIPTION
For generate-groups.sh and generate-internal-groups.sh existing built-in
shell variable handling can be used instead of calling external programs
basename and dirname. Also remove some superfluous quotes to improve
readability.

Change-Id: I42dd1f88754d589ed236ecc824c0f3ceb6fbbc7c
Signed-off-by: Joakim Roubert <joakimr@axis.com>

Sorry, we do not accept changes directly against this repository. Please see
CONTRIBUTING.md for information on where and how to contribute instead.
