### PR TITLE
kube_codegen: smarter grepping of +genclient directive

### DIFF
--- a/kube_codegen.sh
+++ b/kube_codegen.sh
@@ -568,7 +568,7 @@ function kube::codegen::gen_client() {
         fi
     done < <(
         ( kube::codegen::internal::grep -l --null \
-            -e '+genclient' \
+            -e '//\s*+genclient' \
             -r "${in_dir}${one_input_api}" \
             --include '*.go' \
             || true \


### PR DESCRIPTION
Try to be smarter about finding the input packages for genclient et al. The previous grep pattern was too generic. This causedcode-generator e.g. to pick it's own auto-generated packages (having a status field adds a comment to the type like "// Add a +genclient:noStatus comment above the type..."). This, in turn causes problems in some cases where the input (api) and the target package for the auto-generated code reside in separate go modules.

Sorry, we do not accept changes directly against this repository. Please see
CONTRIBUTING.md for information on where and how to contribute instead.
